### PR TITLE
Adds gtsam and boost for it.

### DIFF
--- a/modules/boost/1.8.0/MODULE.bazel
+++ b/modules/boost/1.8.0/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "boost",
+    version = "1.8.0",
+    compatibility_level = 1,
+)
+bazel_dep(name = "rules_cc", version = "0.0.2")
+bazel_dep(name = "rules_foreign_cc", version = "0.9.0")

--- a/modules/boost/1.8.0/patches/add_build_file.patch
+++ b/modules/boost/1.8.0/patches/add_build_file.patch
@@ -1,0 +1,42 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,38 @@
++load("@rules_foreign_cc//foreign_cc:defs.bzl", "boost_build")
++
++package(default_visibility = ["//visibility:public"])
++
++filegroup(
++    name = "all_srcs",
++    srcs = glob(["**"]),
++    visibility = ["//visibility:public"],
++)
++
++boost_build(
++    name = "boost_for_gtsam",
++    lib_source = ":all_srcs",
++    linkopts = ["-lpthread"],
++    out_shared_libs = [
++        "libboost_serialization.so",
++        "libboost_system.so",
++        "libboost_filesystem.so",
++        "libboost_thread.so",
++        "libboost_program_options.so",
++        "libboost_date_time.so",
++        "libboost_timer.so",
++        "libboost_chrono.so",
++        "libboost_regex.so",
++    ],
++    user_options = [
++        "--with-serialization",
++        "--with-system",
++        "--with-filesystem",
++        "--with-thread",
++        "--with-program_options",
++        "--with-date_time",
++        "--with-timer",
++        "--with-chrono",
++        "--with-regex",
++        "-j 8",
++    ],
++)
+

--- a/modules/boost/1.8.0/source.json
+++ b/modules/boost/1.8.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-SyE2+YvdH1hX8cPeqawgGO/+ZShs8lFTS2riDMReGEc=",
+    "patch_strip": 0,
+    "patches": {
+        "add_build_file.patch": "sha256-2d+y2NSMyb8LoEEF7T4g9BKCRQyupIwFmzIAfWrVNgA="
+    },
+    "strip_prefix": "boost_1_80_0",
+    "url": "https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.tar.gz"
+}

--- a/modules/boost/metadata.json
+++ b/modules/boost/metadata.json
@@ -1,0 +1,8 @@
+{
+    "homepage": "https://www.boost.org/",
+    "maintainers": [],
+    "versions": [
+        "1.8.0"
+    ],
+    "yanked_versions": {}
+}

--- a/modules/gtsam/4.1.1/MODULE.bazel
+++ b/modules/gtsam/4.1.1/MODULE.bazel
@@ -1,0 +1,8 @@
+module(
+    name = "gtsam",
+    version = "4.1.1",
+    compatibility_level = 1,
+)
+bazel_dep(name = "rules_cc", version = "0.0.2")
+bazel_dep(name = "rules_foreign_cc", version = "0.9.0")
+bazel_dep(name = "boost", version = "1.8.0")

--- a/modules/gtsam/4.1.1/patches/add_build_file.patch
+++ b/modules/gtsam/4.1.1/patches/add_build_file.patch
@@ -1,0 +1,29 @@
+--- /dev/null
++++ BUILD.bazel
+@@ -0,0 +1,26 @@
++load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
++
++filegroup(
++    name = "all_srcs",
++    srcs = glob(["**"]),
++    visibility = ["//visibility:public"],
++)
++
++cmake(
++    name = "gtsam",
++    cache_entries = {
++        "CMAKE_CXX_FLAGS": "-fPIC",
++        "BUILD_SHARED_LIBS": "ON",
++        "CMAKE_BUILD_TYPE": "Release",
++        "GTSAM_BUILD_UNSTABLE": "ON",
++        "GTSAM_UNSTABLE_BUILD_PYTHON": "OFF",
++    },
++    copts = ["-fPIC"],
++    lib_source = ":all_srcs",
++    out_shared_libs = [
++        "libgtsam.so",
++        "libgtsam_unstable.so",
++    ],
++    visibility = ["//visibility:public"],
++    deps = ["@boost:boost_for_gtsam"],
++)

--- a/modules/gtsam/4.1.1/source.json
+++ b/modules/gtsam/4.1.1/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-x7Xmza1SsUHCcnePR7r2KJdUV74+Ju2Wp7wq5oWgCvA=",
+    "patch_strip": 0,
+    "patches": {
+        "add_build_file.patch": "sha256-T/wJiblRqRxaHGGWNj9V2QkA6mZL+uEPJmClddC6o+Y="
+    },
+    "strip_prefix": "gtsam-4.1.1",
+    "url": "https://github.com/borglab/gtsam/archive/refs/tags/4.1.1.tar.gz"
+}

--- a/modules/gtsam/metadata.json
+++ b/modules/gtsam/metadata.json
@@ -1,0 +1,8 @@
+{
+    "homepage": "https://github.com/borglab/gtsam/",
+    "maintainers": [],
+    "versions": [
+        "4.1.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
The way building boost seems to work is you can specify which specific pieces you want to build with. So, for now at least, the boost module has a single `boost_for_gtsam` target with the specific dependences gtsam wants. We can experiment with better ways to handle this down the line.