### PR TITLE
adds pigpio

### DIFF
--- a/modules/pigpio/79.0/MODULE.bazel
+++ b/modules/pigpio/79.0/MODULE.bazel
@@ -1,0 +1,5 @@
+module(
+    name = "pigpio",
+    version = "79.0",
+    compatibility_level = 1,
+)

--- a/modules/pigpio/79.0/patches/add_build_file.patch
+++ b/modules/pigpio/79.0/patches/add_build_file.patch
@@ -1,0 +1,22 @@
+--- /dev/null
++++ a/BUILD.bazel
+@@ -0,0 +1,19 @@
++package(default_visibility = ["//visibility:public"])
++
++cc_library(
++    name = "pigpio",
++    srcs = [
++        "pigpio.c",
++        "command.c",
++        "custom.c",
++    ],
++    hdrs = [
++        "pigpio.h",
++        "command.h",
++    ],
++    include_prefix = "pigpio/",
++    linkopts = [
++        "-lpthread",
++        "-lrt",
++        ],
++)

--- a/modules/pigpio/79.0/patches/patch.txt
+++ b/modules/pigpio/79.0/patches/patch.txt
@@ -1,0 +1,25 @@
+--- pigpio-master/custom.c	1969-12-31 17:00:00.000000000 -0700
++++ pigpio-master-modified/custom.c	2022-11-16 12:25:17.065637184 -0700
+@@ -0,0 +1,12 @@
++#include "pigpio.h"
++
++int gpioCustom1(unsigned arg1, unsigned arg2, char *argx, unsigned count)
++{
++    return 0;
++}
++
++int gpioCustom2(unsigned arg1, char *argx, unsigned count,
++                char *retBuf, unsigned retMax)
++{
++    return 0;
++}
+
+--- pigpio-master/pigpio.c	2021-03-02 11:46:53.000000000 -0700
++++ pigpio-master-modified/pigpio.c	2022-11-16 13:17:46.596448990 -0700
+@@ -14031,6 +14031,3 @@
+ 
+ 
+ /* include any user customisations */
+-
+-#include "custom.cext"
+-

--- a/modules/pigpio/79.0/source.json
+++ b/modules/pigpio/79.0/source.json
@@ -1,0 +1,10 @@
+{
+    "integrity": "sha256-yrxBpyYQLWt0YjyMJ25lwdEQ2+p7b4Pem9pJCm6JtJk=",
+    "patch_strip": 1,
+    "patches": {
+        "add_build_file.patch": "sha256-4ohlqpnWiHYxXPWjhiCyy0B+zOw7rSA1iBnEI5v6Y7s=",
+        "patch.txt": "sha256-zvH2B33ZjKI8Toc9GlOxB67pegoCFFuEFVn//vDir6c="
+    },
+    "strip_prefix": "pigpio-master/",
+    "url": "https://github.com/joan2937/pigpio/archive/master.zip"
+}

--- a/modules/pigpio/metadata.json
+++ b/modules/pigpio/metadata.json
@@ -1,0 +1,8 @@
+{
+    "homepage": "https://abyz.me.uk/rpi/pigpio/index.html",
+    "maintainers": [],
+    "versions": [
+        "79.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
This adds the new pi GPIO library pigpio

we may want to consider removing wiringpi so it is not used in the future