### PR TITLE
Add a version and name check

### DIFF
--- a/.github/workflows/call_add_module.yml
+++ b/.github/workflows/call_add_module.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   call-add-module:
-    uses: pattern-labs/index-registry/.github/workflows/add_module.yml@main
+    uses: pattern-labs/index-registry/.github/workflows/add_module.yml@enh/check_version
     with:
       module_name: ${{ github.event.inputs.module_name }}
       version: ${{ github.event.inputs.version }}

--- a/.github/workflows/call_add_module.yml
+++ b/.github/workflows/call_add_module.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   call-add-module:
-    uses: pattern-labs/index-registry/.github/workflows/add_module.yml@enh/check_version
+    uses: pattern-labs/index-registry/.github/workflows/add_module.yml@main
     with:
       module_name: ${{ github.event.inputs.module_name }}
       version: ${{ github.event.inputs.version }}

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -332,6 +332,8 @@ module(
       # Setup conditionals.
       module_start = False
       module_end = False
+      correct_name = False
+      correct_version = False
       # Parse through lines.
       with open(module.module_dot_bazel) as file:
         lines = file.readlines()
@@ -364,6 +366,7 @@ module(
                     raise RegistryException(
                         f"BAZEL.module name: {module_name_match.group(2)} != module_name: {module.name}"
                     )
+                correct_name = True
                 continue
             # Look for module version definition.
             module_version_match = MODULE_VERSION_REGEX.search(line)
@@ -372,7 +375,12 @@ module(
                     raise RegistryException(
                         f"BAZEL.module version: {module_version_match.group(2)} != version_name: {module.version}"
                     )
+                correct_version = True
                 continue
+      if not ( correct_name and correct_version and module_start and module_end ):
+        raise RegistryException(
+          f"Correct Version: {correct_version}, Correct Name: {correct_name}, Module Start: {module_start}, Module End {module_end}"
+        )
       shutil.copy(module.module_dot_bazel, module_dot_bazel)
     else:
       deps = "\n".join(

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -338,6 +338,7 @@ module(
       with open(module.module_dot_bazel) as file:
         lines = file.readlines()
       for line in lines:
+        print(line)
         # Looking for start of module definition.
         if module_start is False and module_end is False:
             # Look for end of module definition.

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -338,7 +338,6 @@ module(
       with open(module.module_dot_bazel) as file:
         lines = file.readlines()
       for line in lines:
-        print(line)
         # Looking for start of module definition.
         if module_start is False and module_end is False:
             # Look for end of module definition.


### PR DESCRIPTION
This adds a check to make sure that the module name and version in the pulled MODULE.bazel file match the inputs from the json file. 

This was tested and on pattern_python tools 0.29.0 and 0.40.0 which failed then passed respectively which is to be expected as 0.29.0 has an incorrect version name.