### PR TITLE
Add workflow to set tag based off MODULE.bazel

### DIFF
--- a/.github/workflows/set_tag.yml
+++ b/.github/workflows/set_tag.yml
@@ -14,7 +14,6 @@ jobs:
         with:
           repository: "pattern-labs/index-registry"
           token: ${{ secrets.REPO_ACCESS_PAT }}
-          ref: feat/set-tag
 
       - name: Get branch name
         id: branch-name
@@ -25,7 +24,6 @@ jobs:
         with:
           repository: pattern-labs/${{ github.event.repository.name }}
           token: ${{ secrets.REPO_ACCESS_PAT }}
-          ref: feat/set-tag
           path: local_repo
 
       - name: Get Tag

--- a/.github/workflows/set_tag.yml
+++ b/.github/workflows/set_tag.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           repository: "pattern-labs/index-registry"
           token: ${{ secrets.REPO_ACCESS_PAT }}
-          ref: 37dcffd319c481246d76df7e4c6ed42c164f08b3
+          ref: "feat/set-tag"
 
       - name: Get branch name
         id: branch-name

--- a/.github/workflows/set_tag.yml
+++ b/.github/workflows/set_tag.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           repository: "pattern-labs/index-registry"
           token: ${{ secrets.REPO_ACCESS_PAT }}
-          ref: "feat/set-tag"
+          ref: main
 
       - name: Get branch name
         id: branch-name

--- a/.github/workflows/set_tag.yml
+++ b/.github/workflows/set_tag.yml
@@ -1,0 +1,40 @@
+name: Set Correct Tag
+
+on:
+  workflow_call:
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Index Registry
+        uses: actions/checkout@v3
+        with:
+          repository: "pattern-labs/index-registry"
+          token: ${{ secrets.REPO_ACCESS_PAT }}
+          ref: main
+
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v6
+
+      - name: Checkout branch
+        uses: actions/checkout@v3
+        with:
+          repository: pattern-labs/${{ github.event.repository.name }}
+          token: ${{ secrets.REPO_ACCESS_PAT }}
+          ref: main
+          path: local_repo
+
+      - name: Get Tag
+        run: python3 .github/workflows/tools/main.py --local --module-name ${{ github.event.repository.name }} --export-tag
+
+      - name: Git Login
+        uses: oleksiyrudenko/gha-git-credentials@v2-latest
+        with:
+          token: '${{ secrets.REPO_ACCESS_PAT }}'
+      
+      - name: Set Tag
+        run: |
+          cd local_repo
+          git tag ${{ env.PATTERN_VERSION_NUMBER }}
+          git push origin ${{ env.PATTERN_VERSION_NUMBER }} -v

--- a/.github/workflows/set_tag.yml
+++ b/.github/workflows/set_tag.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           repository: "pattern-labs/index-registry"
           token: ${{ secrets.REPO_ACCESS_PAT }}
+          ref: 37dcffd319c481246d76df7e4c6ed42c164f08b3
 
       - name: Get branch name
         id: branch-name
@@ -25,7 +26,7 @@ jobs:
           repository: pattern-labs/${{ github.event.repository.name }}
           token: ${{ secrets.REPO_ACCESS_PAT }}
           path: local_repo
-
+          ref: 37dcffd319c481246d76df7e4c6ed42c164f08b3
       - name: Get Tag
         run: python3 .github/workflows/tools/main.py --local --module-name ${{ github.event.repository.name }} --export-tag
 

--- a/.github/workflows/set_tag.yml
+++ b/.github/workflows/set_tag.yml
@@ -4,14 +4,17 @@ on:
   workflow_call:
 jobs:
   check-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout Index Registry
         uses: actions/checkout@v3
         with:
           repository: "pattern-labs/index-registry"
           token: ${{ secrets.REPO_ACCESS_PAT }}
-          ref: main
+          ref: feat/set-tag
 
       - name: Get branch name
         id: branch-name
@@ -22,7 +25,7 @@ jobs:
         with:
           repository: pattern-labs/${{ github.event.repository.name }}
           token: ${{ secrets.REPO_ACCESS_PAT }}
-          ref: main
+          ref: feat/set-tag
           path: local_repo
 
       - name: Get Tag

--- a/.github/workflows/set_tag.yml
+++ b/.github/workflows/set_tag.yml
@@ -26,7 +26,8 @@ jobs:
           repository: pattern-labs/${{ github.event.repository.name }}
           token: ${{ secrets.REPO_ACCESS_PAT }}
           path: local_repo
-          ref: 37dcffd319c481246d76df7e4c6ed42c164f08b3
+          ref: main
+
       - name: Get Tag
         run: python3 .github/workflows/tools/main.py --local --module-name ${{ github.event.repository.name }} --export-tag
 

--- a/.github/workflows/tools/main.py
+++ b/.github/workflows/tools/main.py
@@ -9,6 +9,7 @@ from module import Module
 
 def main(args):
     if args["local"]:
+        module = None
         if args["bump_patch"]:
             module = Module(local=True, module_name=args["module_name"][0])
             print("Bumping a local patch")
@@ -42,8 +43,12 @@ def main(args):
 
         # These need to be last. Order matters.
         if args["export_tag"]:
+            if module == None:
+                module = Module(local=True, module_name=args["module_name"][0])
             module.export_version_to_github_env()
         if args["save_local"]:
+            if module == None:
+                module = Module(local=True, module_name=args["module_name"][0])
             print("Saving a local module")
             module.save_version(override=True)
     elif args["index"]:


### PR DESCRIPTION
This adds in a new workflow which will tag a repo based on the MODULE.bazel version. This will trigger when things are merged with main. If the tag is already set then it will fail. It gets called by other repos using a workflow call. Planning to implement on guardrail and pattern_tools first. Testing worked on guardrail.